### PR TITLE
Fix crashes under load

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The following symbols can be defined to change the configuration
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE | The size of the queue string TCP events to process | CONFIG_LWIP_MAX_ACTIVE_TCP * 4 == 64 |
 | CONFIG_ASYNC_TCP_RUNNING_CORE | The CPU core to run the async task on | -1 (any cpu) |
 | CONFIG_ASYNC_TCP_USE_WDT | If the watchdog timer should be enabled while processing TCP messages. Set to 0 to disable | 1 (enabled) | 
 | CONFIG_ASYNC_TCP_TASK_STACK_SIZE | The number of 32-bit words (not bytes!) to allocate for use as the task's stack. | 8192 | 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ If the value from this function is close to zero, increasing CONFIG_ASYNC_TCP_TA
 static UBaseType_t AsyncClient::getStackHighWaterMark()
 ```
 
-### 
+## Known issues
 
-### Async TCP Library for ESP32 Arduino
+There is a potential race between AsyncClient::space() and an incoming error event, where the LwIP task might free the tcp_pcb while a client task is accessing it.  We are (currently) accepting this risk as the cost of synchronizing across the tcp_pcb access is very large compared to the lookup cost, and error events are very infrequent in normal operation.
+
+## Async TCP Library for ESP32 Arduino
 
 [![Join the chat at https://gitter.im/me-no-dev/ESPAsyncWebServer](https://badges.gitter.im/me-no-dev/ESPAsyncWebServer.svg)](https://gitter.im/me-no-dev/ESPAsyncWebServer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -90,6 +90,7 @@ static lwip_event_packet_t* _alloc_event(lwip_event_t event, AsyncClient* client
     // Validation check
     if (pcb && (client->pcb() != pcb)) {
         // Client structure is corrupt?
+        log_e("Client mismatch allocating event for 0x%08x 0x%08x vs 0x%08x\n",(intptr_t)client, (intptr_t)pcb,client->pcb());
         tcp_abort(pcb);
         _tcp_error(client, ERR_ARG);
         return nullptr;
@@ -99,6 +100,7 @@ static lwip_event_packet_t* _alloc_event(lwip_event_t event, AsyncClient* client
 
     if (!e) {
         // Allocation fail - abort client and give up
+        log_e("OOM allocating event for 0x%08x 0x%08x\n",(intptr_t)client, (intptr_t)pcb);
         if (pcb) tcp_abort(pcb);
         _tcp_error(client, ERR_MEM);
         return nullptr;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -308,9 +308,9 @@ static void _async_service_task(void *pvParameters){
 #endif
         }
         // queue is empty
-        DEBUG_PRINTF("Async task waiting 0x%08\n",(intptr_t)_async_queue_head);
-        auto q = ulTaskNotifyTake(pdTRUE, 1000);
-        DEBUG_PRINTF("Async task woke = %d 0x%08x\n",q, (intptr_t)_async_queue_head);
+        // DEBUG_PRINTF("Async task waiting 0x%08\n",(intptr_t)_async_queue_head);
+        auto q = ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        // DEBUG_PRINTF("Async task woke = %d 0x%08x\n",q, (intptr_t)_async_queue_head);
     }
     vTaskDelete(NULL);
     _async_service_task_handle = NULL;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -141,9 +141,13 @@ static inline bool _send_async_event(lwip_event_packet_t * e){
             _async_queue_head = e;            
         }
         _async_queue_tail = e;
+#ifdef ASYNC_TCP_DEBUG        
         uint32_t n;
         xTaskNotifyAndQuery(_async_service_task_handle, 1, eIncrement, &n);
         DEBUG_PRINTF("SAA: 0x%08x -> 0x%08x 0x%08x - %d\n",(intptr_t) e, (intptr_t)_async_queue_head, (intptr_t)_async_queue_tail,n);
+#else
+        xTaskNotifyGive(_async_service_task_handle);
+#endif
     }
     return (bool) guard;
 }
@@ -157,9 +161,13 @@ static inline bool _prepend_async_event(lwip_event_packet_t * e) {
             _async_queue_tail = e;            
         }
         _async_queue_head = e;
+#ifdef ASYNC_TCP_DEBUG        
         uint32_t n;
         xTaskNotifyAndQuery(_async_service_task_handle, 1, eIncrement, &n);
         DEBUG_PRINTF("PAA: 0x%08x -> 0x%08x 0x%08x - %d\n",(intptr_t) e, (intptr_t)_async_queue_head, (intptr_t)_async_queue_tail,n);
+#else
+        xTaskNotifyGive(_async_service_task_handle);
+#endif   
     }
     return (bool) guard;
 }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -31,10 +31,8 @@ extern "C"{
 }
 #include "esp_task_wdt.h"
 
-//#define ASYNC_TCP_DEBUG
 #ifdef ASYNC_TCP_DEBUG
-#define DEBUG_PRINTF(...) Serial.printf(__VA_ARGS__);
-//log_d(__VA_ARGS__)
+#define DEBUG_PRINTF(...) log_d(__VA_ARGS__)
 #else
 #define DEBUG_PRINTF(...)
 #endif

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -42,7 +42,7 @@ extern "C"{
  * */
 
 typedef enum {
-    LWIP_TCP_SENT, LWIP_TCP_RECV, LWIP_TCP_FIN, LWIP_TCP_ERROR, LWIP_TCP_POLL, LWIP_TCP_CLEAR, LWIP_TCP_ACCEPT, LWIP_TCP_CONNECTED, LWIP_TCP_DNS
+    LWIP_TCP_SENT, LWIP_TCP_RECV, LWIP_TCP_FIN, LWIP_TCP_ERROR, LWIP_TCP_POLL, LWIP_TCP_ACCEPT, LWIP_TCP_CONNECTED, LWIP_TCP_DNS
 } lwip_event_t;
 
 struct lwip_event_packet_t {
@@ -245,10 +245,7 @@ static void _teardown_pcb(tcp_pcb* pcb) {
 
 void AsyncClient_detail::handle_async_event(lwip_event_packet_t * e){
     // Special cases first
-    if(e->event == LWIP_TCP_CLEAR){
-        DEBUG_PRINTF("-X: 0x%08x %d\n", e->client);
-        _remove_events_for(e->client);
-    } else if(e->event == LWIP_TCP_ERROR){
+    if(e->event == LWIP_TCP_ERROR){
         DEBUG_PRINTF("-E: 0x%08x %d\n", e->client, e->error.err);
         // Special case: pcb is now invalid
         // _remove_events_for(e->client);  // there oughtn't be any

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -74,6 +74,7 @@ typedef std::function<void(void*, AsyncClient*, uint32_t time)> AcTimeoutHandler
 struct tcp_pcb;
 struct ip_addr;
 class AsyncClient_detail;
+struct lwip_event_packet_t;
 
 class AsyncClient {
   public:
@@ -166,6 +167,7 @@ class AsyncClient {
 
   protected:
     tcp_pcb* _pcb;
+    lwip_event_packet_t* _end_event;
 
     AcConnectHandler _connect_cb;
     void* _connect_cb_arg;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -34,10 +34,6 @@ extern "C" {
 //CONFIG_ASYNC_TCP_DIAGNOSTICS
 //#define CONFIG_ASYNC_TCP_DIAGNOSTICS 1
 
-#ifndef CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE
-#define CONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE (CONFIG_LWIP_MAX_ACTIVE_TCP * 4)
-#endif
-
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core


### PR DESCRIPTION
Reimplement event queuing and tcp_pcb close handling so as to eliminate the possibility of leaving AsyncClient objects "stuck" should the system OOM or otherwise experience resource exhaustion.

Key changes:
- FreeRTOS event queue replaced with "condvar" + linked list, allowing the LwIP thread to take responsibility for purging obsolete events; also no need to define queue size.
- Eliminate close slot tracking by referencing client object memory directly.
- In the event of any event allocation or queuing failure, ensures that an error event is queued for the client object.

Benchmarks on ESP32 and -S2 show no change in performance; the limiting factors seem to be elsewhere in the stack.